### PR TITLE
[Fix] groupName 매개변수가 사용되지 않음을 명시

### DIFF
--- a/src/pages/compliment/ComplimentDetailPage.tsx
+++ b/src/pages/compliment/ComplimentDetailPage.tsx
@@ -46,7 +46,7 @@ const ComplimentDetailPage = () => {
     }
   };
 
-  const handleSelectedGroup = (groupName: string, selectedGroupId: number) => {
+  const handleSelectedGroup = (_groupName: string, selectedGroupId: number) => {
     setShowGroupModal(false);
     // setGroupId(selectedGroupId);
 


### PR DESCRIPTION
## 연관 이슈

DD-115

<br/>

## 개요

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요. -->
groupName 매개변수가 사용되지 않음을 명시해 배포 오류 수정
<br/>

### 📝 기타 사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업 등을 적어주세요. -->
- `GroupModal.tsx`에서 onConfirm을 props로 받는데 이때 타입이 `(groupId: number) -> void` 인 경우도 있고, `(groupName: string, groupId:number) -> void` 인 경우도 있어요! 근데 파라미터인 groupName을 `onConfirm: (groupName?: string, groupId: number) => void;` 이런 식으로 선택적으로 입력받는 것이 어렵고 두 경우 모두 허용하자니 아래와 같은 에러가 발생하여 `_` 언더바를 추가하여 본 매개변수가 함수 내부에서 사용되지 않음을 명시적으로 표현하도록해 에러를 제거하였습니다!

> selectedGroupId를 groupName에 매핑하려고 시도했지만, string 타입으로 예상했던 groupName과 실제 전달된 number 타입의 값이 호환되지 않아 타입 충돌이 발생.
즉, TypeScript는 함수가 (groupId: number) => void처럼 작동할지, (groupName: string, groupId: number) => void처럼 작동할지 혼란

<br/>

<br/>
