### PR TITLE
[Feat] 꿀 옮기기 및 꿀 삭제 API 연동

### DIFF
--- a/src/api/auth/postReissue.ts
+++ b/src/api/auth/postReissue.ts
@@ -1,12 +1,12 @@
 import basicAxios from '@/api/basicAxios';
 
-export const postReissue = async() => {
+export const postReissue = async (accessToken: string, refreshToken:string) => {
   const endpoint = '/api/auth/reissue';
 
   try {
-    const response = await basicAxios.post(endpoint, {});
+    const response = await basicAxios.post(endpoint, {accessToken: accessToken, refreshToken: refreshToken});
     console.log('토큰 재발급 성공:', response);
-    return response.data;
+    return response.data.data;
   } catch (error) {
     console.error('토큰 재발급 실패:', error);
     throw error;

--- a/src/api/authAxios.tsx
+++ b/src/api/authAxios.tsx
@@ -60,7 +60,7 @@ authAxios.interceptors.response.use(
         console.error('토큰 갱신 중 에러 발생:', refreshError);
         removeAccessToken();
         removeRefreshToken();
-        window.location.href = '/login';
+        // window.location.href = '/login';
         return Promise.reject(refreshError);
       }
     } else {

--- a/src/api/authAxios.tsx
+++ b/src/api/authAxios.tsx
@@ -1,7 +1,10 @@
 import {
   getAccessToken,
+  getRefreshToken,
   removeAccessToken,
   removeRefreshToken,
+  setAccessToken,
+  setRefreshToken,
 } from '@/utils/storage';
 import axios, { AxiosInstance, InternalAxiosRequestConfig } from 'axios';
 import { postReissue } from './auth/postReissue';
@@ -36,30 +39,33 @@ authAxios.interceptors.response.use(
     } = error;
     const originalRequest = error.config;
     /* 토큰 만료 시 */
+    const accessToken = getAccessToken() || '';
+    const refreshToken = getRefreshToken() || '';
     if (status === 401) {
-      // 토큰 재발급 로직
       try {
-        const newAccessToken = await postReissue().catch((tokenError) => {
-          console.error('토큰 갱신 실패:', tokenError);
-          throw tokenError;
-        });
+        const newToken = await postReissue(accessToken, refreshToken).catch(
+          (tokenError) => {
+            console.error('토큰 갱신 실패:', tokenError);
+            throw tokenError;
+          }
+        );
 
-        if (newAccessToken) {
-          console.log('액세스 토큰 발급 중');
-          originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+        if (newToken) {
+          setAccessToken(newToken.accessToken);
+          setRefreshToken(newToken.refreshToken);
+          originalRequest.headers.Authorization = `Bearer ${newToken.accessToken}`;
           return authAxios(originalRequest);
         }
       } catch (refreshError) {
         console.error('토큰 갱신 중 에러 발생:', refreshError);
         removeAccessToken();
         removeRefreshToken();
-        // window.location.href = '/login';
+        window.location.href = '/login';
         return Promise.reject(refreshError);
       }
     } else {
-      const accessToken = getAccessToken();
       if (!accessToken) {
-        // window.location.href = '/login';
+        window.location.href = '/login';
       }
     }
     return Promise.reject(error);

--- a/src/api/group/getGroupSearch.ts
+++ b/src/api/group/getGroupSearch.ts
@@ -4,6 +4,8 @@ import { GroupSearchParams, GroupSearchResponse } from './types/Group';
 export const getGroupSearch = async ({
   groupName,
 }: GroupSearchParams): Promise<GroupSearchResponse> => {
-  const response = await axios.get(`/api/group/search?groupName=${groupName}`);
+  const response = await axios.get(
+    `/api/group/search?groupName=${groupName}`
+  );
   return response.data.data;
 };

--- a/src/api/group/patchReceiveGroupChange.ts
+++ b/src/api/group/patchReceiveGroupChange.ts
@@ -1,0 +1,13 @@
+import { authAxios as axios } from '../authAxios';
+import { PatchGroupChange } from './types/Group';
+
+export const patchReceiveGroupChange = async ({
+  praiseIdList,
+  groupId,
+}: PatchGroupChange) => {
+  const response = await axios.patch(`/api/group/receive-praise/change`, {
+    praiseIdList,
+    groupId,
+  });
+  return response.data.data;
+};

--- a/src/api/group/patchSendGroupChange.ts
+++ b/src/api/group/patchSendGroupChange.ts
@@ -1,0 +1,10 @@
+import { authAxios as axios } from '../authAxios';
+import { PatchGroupChange } from './types/Group';
+
+export const patchSendGroupChange = async ({ praiseIdList, groupId }: PatchGroupChange) => {
+  const response = await axios.patch(`/api/group/send-praise/change`, {
+    praiseIdList,
+    groupId,
+  });
+  return response.data.data;
+};

--- a/src/api/group/postGroup.ts
+++ b/src/api/group/postGroup.ts
@@ -5,5 +5,5 @@ export const postGroup = async ({ groupName }: PostGroupParams) => {
   const response = await axios.post(`/api/group`, {
     groupName,
   });
-  return response.data;
+  return response.data.data;
 };

--- a/src/api/group/types/Group.ts
+++ b/src/api/group/types/Group.ts
@@ -14,11 +14,13 @@ export type GroupCheckResponse = {
   isDuplicate: boolean;
 };
 
+export type GroupOrder = {
+  groupId: number;
+  orderIdx: number;
+};
+
 export type PatchGroupOrder = {
-  groupOrderList: Array<{
-    groupId: number;
-    orderIdx: number;
-  }>;
+  groupOrderList: GroupOrder[];
 };
 
 export type GroupSearchParams = {
@@ -26,7 +28,7 @@ export type GroupSearchParams = {
 };
 
 type GroupMember = {
-  name: string;
+  id: number;
 };
 
 export type GroupWithMembersInfo = {
@@ -55,4 +57,9 @@ type GroupInfo = {
 
 export type GroupSearchResponse = {
   groupInfos: GroupInfo[];
+};
+
+export type PatchGroupChange = {
+  praiseIdList: number[];
+  groupId: number;
 };

--- a/src/api/receivedPraise/deleteReceivedPraise.ts
+++ b/src/api/receivedPraise/deleteReceivedPraise.ts
@@ -1,6 +1,8 @@
 import { authAxios as axios } from '../authAxios';
 
-export const deleteReceivedPraise = async () => {
-  const response = await axios.delete(`/api/receive-praise`);
+export const deleteReceivedPraise = async (ids: number[]) => {
+  const response = await axios.delete(
+    `/api/receive-praise?id=${ids.map(String).join(',')}`
+  );
   return response.data;
 };

--- a/src/api/receivedPraise/types/ReceivedPraise.ts
+++ b/src/api/receivedPraise/types/ReceivedPraise.ts
@@ -14,6 +14,7 @@ export type receivePraiseInfo = {
   name: string;
   content: string;
   stampUrl: string;
+  profileImageUrl: string;
   receiveDate: string;
 };
 

--- a/src/api/receivedPraise/types/ReceivedPraise.ts
+++ b/src/api/receivedPraise/types/ReceivedPraise.ts
@@ -10,7 +10,7 @@ export type GroupReceivedPraiseParams = {
 };
 
 export type receivePraiseInfo = {
-  receivedPraiseId: number;
+  receivePraiseId: number;
   name: string;
   content: string;
   stampUrl: string;

--- a/src/api/sendPraise/types/SendPraise.ts
+++ b/src/api/sendPraise/types/SendPraise.ts
@@ -17,6 +17,7 @@ export type sendPraiseInfo = {
   name: string;
   content: string;
   stampUrl: string;
+  profileImageUrl: string;
   sendDate: string;
 };
 

--- a/src/components/Modal/ProcessModal.tsx
+++ b/src/components/Modal/ProcessModal.tsx
@@ -74,7 +74,7 @@ const ModalOverlay = styled.div`
   top: 0;
   left: 0;
   background: rgba(46, 44, 41, 0.8);
-  z-index: 10;
+  z-index: 30;
 `;
 
 const ModalContainer = styled.div<{ width?: string; height?: string }>`
@@ -97,6 +97,7 @@ const ModalContent = styled.div`
   flex-direction: column;
   align-items: center;
   gap: 20px;
+  overflow: hidden;
 `;
 
 const Title = styled.div`

--- a/src/components/Toggle/DisplayToggle.tsx
+++ b/src/components/Toggle/DisplayToggle.tsx
@@ -26,15 +26,12 @@ const DisplayToggle = (props: DisplayToggleProps) => {
   return (
     <DisplayToggleContainer>
       {iconTypes[displayType].map((type, index) => (
-        <>
-          <DisplayToggleButton
-            key={type}
-            onClick={() => !disabled && onClick(type)}
-          >
+        <React.Fragment key={`${type}-${index}`}>
+          <DisplayToggleButton onClick={() => !disabled && onClick(type)}>
             <img src={getIconPath(type)} width={36} height={36} alt="toggle" />
           </DisplayToggleButton>
           {index === 0 && <Bar />}
-        </>
+        </React.Fragment>
       ))}
     </DisplayToggleContainer>
   );

--- a/src/components/Toggle/TabToggle.tsx
+++ b/src/components/Toggle/TabToggle.tsx
@@ -1,7 +1,7 @@
 import { theme } from '@/styles/theme';
 import styled from '@emotion/styled';
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 export interface Tabs {
   id: number;
@@ -18,12 +18,13 @@ interface TabToggleProps {
 }
 
 const TabToggle = (props: TabToggleProps) => {
-  const { tabs, selected, originalPath, onClick } = props;
+  const { tabs, selected, onClick } = props;
+  const { id: groupId } = useParams();
   const navigate = useNavigate();
 
   const handleTabClick = (id: number, path: string) => {
     onClick(id);
-    navigate(`${originalPath}?tab=${path}`, { replace: true });
+    navigate(`/group/${groupId}?tab=${path}`, { replace: true });
   };
 
   return (

--- a/src/features/Compliment/components/Modal/HoneyMoveCheckModal.tsx
+++ b/src/features/Compliment/components/Modal/HoneyMoveCheckModal.tsx
@@ -33,13 +33,13 @@ const HoneyMoveCheckModal = (props: HoneyMoveCheckModalProps) => {
   // 더미데이터, 추후 서버로부터 반환되는 값으로 저장
   const groupInfo = [
     {
-      id: 0,
+      id: groupId,
       groupName: '도도독',
       groupMemberCount: 8,
       groupMemberName: '박형준',
     },
     {
-      id: 1,
+      id: selectedGroup,
       groupName: '도도독개발그루우우우우우웁웁웁',
       groupMemberCount: 5,
       groupMemberName: '박진우',

--- a/src/features/Compliment/components/Modal/HoneyMoveModal.tsx
+++ b/src/features/Compliment/components/Modal/HoneyMoveModal.tsx
@@ -1,6 +1,7 @@
 import ProcessModal from '@/components/Modal/ProcessModal';
 import GroupListBox from '@/features/Group/components/GroupListBox';
-import { GROUP_LIST_DUMMY } from '@/features/Group/constant/dummy/groupList';
+import { useGroupSearch } from '@/hooks/group/useGroupSearch';
+import styled from '@emotion/styled';
 import React from 'react';
 
 interface HoneyMoveModalProps {
@@ -22,6 +23,9 @@ const HoneyMoveModal = (props: HoneyMoveModalProps) => {
     groupId,
   } = props;
 
+  const { data: groupData } = useGroupSearch('');
+  const groupList = groupData?.groupInfos || [];
+
   const handleSelectGroup = (groupId: number) => {
     if (selectedGroup === groupId) {
       setSelectedGroup(null);
@@ -41,18 +45,29 @@ const HoneyMoveModal = (props: HoneyMoveModalProps) => {
       confirmDisabled={selectedGroup === null}
       isVisible={isVisible}
     >
-      {GROUP_LIST_DUMMY.map((group) => (
-        <GroupListBox
-          key={group.id}
-          id={group.id}
-          currentId={groupId}
-          groupName={group.groupName}
-          selected={group.id === selectedGroup}
-          onClick={() => handleSelectGroup(group.id)}
-        />
-      ))}
+      <GroupList>
+        {groupList?.map((group) => (
+          <GroupListBox
+            key={group.groupId}
+            id={group.groupId}
+            currentId={groupId}
+            groupName={group.groupName}
+            selected={group.groupId === selectedGroup}
+            onClick={() => handleSelectGroup(group.groupId)}
+          />
+        ))}
+      </GroupList>
     </ProcessModal>
   );
 };
 
 export default HoneyMoveModal;
+
+const GroupList = styled.div`
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  overflow-y: scroll;
+`;

--- a/src/features/Compliment/types/HoneyLetter.tsx
+++ b/src/features/Compliment/types/HoneyLetter.tsx
@@ -4,5 +4,6 @@ export interface HoneyLetter {
   receiver: string;
   content: string;
   stampUrl: string;
+  profileImageUrl: string;
   date: string;
 }

--- a/src/features/Group/components/Container/GroupTabContainer.tsx
+++ b/src/features/Group/components/Container/GroupTabContainer.tsx
@@ -70,6 +70,7 @@ const GroupTabContainer = memo((props: GroupTabContainerProps) => {
             receiver: praise.name,
             content: praise.content,
             stampUrl: praise.stampUrl,
+            profileImageUrl: praise.profileImageUrl,
             date: praise.sendDate,
           }))
         )
@@ -83,6 +84,7 @@ const GroupTabContainer = memo((props: GroupTabContainerProps) => {
             receiver: praise.name,
             content: praise.content,
             stampUrl: praise.stampUrl,
+            profileImageUrl: praise.profileImageUrl,
             date: praise.receiveDate,
           }))
         )

--- a/src/features/Group/components/Container/GroupTabContainer.tsx
+++ b/src/features/Group/components/Container/GroupTabContainer.tsx
@@ -11,7 +11,7 @@ import { theme } from '@/styles/theme';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import React, { memo, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 interface GroupTabContainerProps {
   type: 'send' | 'receive' | null;
@@ -25,7 +25,8 @@ const GroupTabContainer = memo((props: GroupTabContainerProps) => {
 
   const navigate = useNavigate();
 
-  const groupId = 1;
+  const { id } = useParams() || '0';
+  const groupId = Number(id);
   const pageSize = 10;
 
   /* React Query 호출 */

--- a/src/features/Group/components/Container/GroupTabContainer.tsx
+++ b/src/features/Group/components/Container/GroupTabContainer.tsx
@@ -1,95 +1,27 @@
-import { GroupReceivePraiseInfo } from '@/api/receivedPraise/types/ReceivedPraise';
-import { GroupSendPraiseInfo } from '@/api/sendPraise/types/SendPraise';
 import Button from '@/components/Button/Button';
 import { ToggleType } from '@/components/Toggle/DisplayToggle';
 import { HoneyLetter } from '@/features/Compliment/types/HoneyLetter';
 import HoneyView from '@/features/Stamp/components/Stamp/StampView/Honey/HoneyView';
 import ListView from '@/features/Stamp/components/Stamp/StampView/List/ListView';
-import { useGroupReceivedPraise } from '@/hooks/receivedPraise/useGroupReceivedPraise';
-import { useGroupSendPraise } from '@/hooks/sendPraise/useGroupSendPraise';
 import { theme } from '@/styles/theme';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import React, { memo, useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import React, { memo } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 interface GroupTabContainerProps {
-  type: 'send' | 'receive' | null;
   displayType: ToggleType;
   isSelectMode: boolean;
   selectedIds: number[];
   onSelectedChange: (selectedIds: number[]) => void;
+  letters: HoneyLetter[];
 }
 
 const GroupTabContainer = memo((props: GroupTabContainerProps) => {
-  const { type, displayType, isSelectMode, selectedIds, onSelectedChange } =
+  const { displayType, isSelectMode, selectedIds, onSelectedChange, letters } =
     props;
 
   const navigate = useNavigate();
-
-  const { id } = useParams() || '0';
-  const groupId = Number(id);
-  const pageSize = 10;
-
-  /* React Query 호출 */
-  const queryHook =
-    type === 'receive'
-      ? useGroupReceivedPraise({
-          groupId,
-          size: pageSize,
-          page: 0,
-        })
-      : type === 'send'
-        ? useGroupSendPraise({
-            groupId,
-            size: pageSize,
-            page: 0,
-          })
-        : null;
-
-  const data = queryHook?.data;
-  console.log('data', data);
-  const fetchNextPage = queryHook?.fetchNextPage;
-  const hasNextPage = queryHook?.hasNextPage;
-  const isFetching = queryHook?.isFetching;
-
-  /* 페이지 끝까지 데이터 가져오기 */
-  useEffect(() => {
-    if (hasNextPage && !isFetching) {
-      fetchNextPage?.();
-    }
-  }, [hasNextPage, isFetching]);
-
-  let letters: HoneyLetter[] = [];
-  if (type === 'send') {
-    letters = data
-      ? data.pages.flatMap((page) =>
-          (page as GroupSendPraiseInfo).sendPraiseInfos.map((praise) => ({
-            id: praise.sendPraiseId,
-            sender: praise.name,
-            receiver: praise.name,
-            content: praise.content,
-            stampUrl: praise.stampUrl,
-            profileImageUrl: praise.profileImageUrl,
-            date: praise.sendDate,
-          }))
-        )
-      : [];
-  } else if (type === 'receive') {
-    letters = data
-      ? data.pages.flatMap((page) =>
-          (page as GroupReceivePraiseInfo).receivePraiseInfos.map((praise) => ({
-            id: praise.receivedPraiseId,
-            sender: praise.name,
-            receiver: praise.name,
-            content: praise.content,
-            stampUrl: praise.stampUrl,
-            profileImageUrl: praise.profileImageUrl,
-            date: praise.receiveDate,
-          }))
-        )
-      : [];
-  }
 
   const handleWriteCompliment = () => {
     // 칭찬 작성하기 페이지 이동

--- a/src/features/Group/components/Container/GroupTabContainer.tsx
+++ b/src/features/Group/components/Container/GroupTabContainer.tsx
@@ -17,11 +17,13 @@ interface GroupTabContainerProps {
   type: 'send' | 'receive' | null;
   displayType: ToggleType;
   isSelectMode: boolean;
-  onSelectedChange: (count: number) => void;
+  selectedIds: number[];
+  onSelectedChange: (selectedIds: number[]) => void;
 }
 
 const GroupTabContainer = memo((props: GroupTabContainerProps) => {
-  const { type, displayType, isSelectMode, onSelectedChange } = props;
+  const { type, displayType, isSelectMode, selectedIds, onSelectedChange } =
+    props;
 
   const navigate = useNavigate();
 
@@ -108,12 +110,14 @@ const GroupTabContainer = memo((props: GroupTabContainerProps) => {
         <HoneyView
           letters={letters}
           isSelectMode={isSelectMode}
+          selectedIds={selectedIds}
           onSelectedChange={onSelectedChange}
         />
       ) : (
         <ListView
           letters={letters}
           isSelectMode={isSelectMode}
+          selectedIds={selectedIds}
           onSelectedChange={onSelectedChange}
         />
       )}

--- a/src/features/Stamp/components/Stamp/HoneyStamp.tsx
+++ b/src/features/Stamp/components/Stamp/HoneyStamp.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 export type NameType = 'receiver' | 'sender';
 
 interface HoneyStamp {
+  id: number;
   profileImg: string;
   nameType: NameType;
   name: string;
@@ -20,6 +21,7 @@ interface HoneyStamp {
 
 const HoneyStamp = (props: HoneyStamp) => {
   const {
+    id,
     profileImg,
     nameType,
     name,
@@ -38,6 +40,7 @@ const HoneyStamp = (props: HoneyStamp) => {
       onClick();
     } else {
       openDetailModal({
+        id,
         profileImg,
         nameType,
         name,

--- a/src/features/Stamp/components/Stamp/StampList.tsx
+++ b/src/features/Stamp/components/Stamp/StampList.tsx
@@ -1,12 +1,13 @@
 import Check from '@/components/Check/Check';
-import DetailHoneyModal from '@/features/Compliment/components/Modal/DetailHoneyModal';
+import { useDetailHoneyModalStore } from '@/store/useDetailHoneyModalStore';
 import { theme } from '@/styles/theme';
 import styled from '@emotion/styled';
-import React, { useState } from 'react';
+import React from 'react';
 
 export type NameType = 'receiver' | 'sender';
 
 interface StampListProps {
+  id: number;
   profileImg: string;
   nameType: NameType;
   name: string;
@@ -20,6 +21,7 @@ interface StampListProps {
 
 const StampList = (props: StampListProps) => {
   const {
+    id,
     profileImg,
     nameType,
     name,
@@ -30,24 +32,21 @@ const StampList = (props: StampListProps) => {
     readOnly,
     onClick,
   } = props;
-
-  const [showDetailHoneyModal, setShowDetailHoneyModal] =
-    useState<boolean>(false);
+  const { openDetailModal } = useDetailHoneyModalStore();
 
   const handleClickStamp = (e: React.MouseEvent<HTMLDivElement>) => {
     e.stopPropagation();
     if (readOnly) {
-      setShowDetailHoneyModal(true);
+      openDetailModal({
+        id,
+        profileImg,
+        nameType,
+        name,
+        content,
+        imgUrl,
+        date,
+      });
     }
-  };
-
-  const handleSaveDetailHoney = () => {
-    // 이미지 저장하기
-    setShowDetailHoneyModal(false);
-  };
-
-  const handleCloseDetailHoney = () => {
-    setShowDetailHoneyModal(false);
   };
 
   return (
@@ -74,19 +73,6 @@ const StampList = (props: StampListProps) => {
         </LeftElement>
         <StampImage src={imgUrl} width={55} height={55} alt="꿀도장" />
       </StampListBox>
-      {showDetailHoneyModal && (
-        <DetailHoneyModal
-          profileImg={profileImg}
-          groupName="groupName"
-          date={date}
-          nameType={nameType}
-          name={name}
-          content={content}
-          stampImage={imgUrl}
-          onConfirm={handleSaveDetailHoney}
-          onClose={handleCloseDetailHoney}
-        />
-      )}
     </>
   );
 };

--- a/src/features/Stamp/components/Stamp/StampView/Honey/HoneyView.tsx
+++ b/src/features/Stamp/components/Stamp/StampView/Honey/HoneyView.tsx
@@ -56,9 +56,9 @@ const HoneyView = (props: HoneyViewProps) => {
         {columns.map((columnLetters, index) => (
           <Column key={index} $isEven={index % 2 !== 0} $index={index}>
             {columnLetters.map((letter) => (
-              <>
+              <React.Fragment key={letter.id}>
                 <HoneyStamp
-                  key={letter.id}
+                  id={letter.id}
                   profileImg={letter.profileImageUrl}
                   nameType={nameType}
                   name={letter.sender}
@@ -69,7 +69,7 @@ const HoneyView = (props: HoneyViewProps) => {
                   readOnly={!isSelectMode}
                   onClick={() => handleCheckHoneyStamp(letter.id)}
                 />
-              </>
+              </React.Fragment>
             ))}
           </Column>
         ))}

--- a/src/features/Stamp/components/Stamp/StampView/Honey/HoneyView.tsx
+++ b/src/features/Stamp/components/Stamp/StampView/Honey/HoneyView.tsx
@@ -6,14 +6,14 @@ import HoneyStamp, { NameType } from '../../HoneyStamp';
 interface HoneyViewProps {
   letters: HoneyLetter[];
   isSelectMode: boolean;
-  onSelectedChange: (count: number) => void;
+  selectedIds: number[];
+  onSelectedChange: (selectedIds: number[]) => void;
 }
 
 const HoneyView = (props: HoneyViewProps) => {
-  const { letters, isSelectMode, onSelectedChange } = props;
+  const { letters, isSelectMode, selectedIds, onSelectedChange } = props;
 
   const [nameType, setNameType] = useState<NameType>('sender');
-  const [selected, setSelected] = useState<number[]>([]);
 
   useEffect(() => {
     const urlParams = new URLSearchParams(location.search);
@@ -27,9 +27,9 @@ const HoneyView = (props: HoneyViewProps) => {
 
   useEffect(() => {
     if (!isSelectMode) {
-      setSelected([]);
+      onSelectedChange([]);
     }
-  }, [isSelectMode]);
+  }, [isSelectMode, onSelectedChange]);
 
   const columns = [];
   let index = 0;
@@ -43,14 +43,11 @@ const HoneyView = (props: HoneyViewProps) => {
   }
 
   const handleCheckHoneyStamp = (id: number) => {
-    const updatedSelected = selected.includes(id)
-      ? selected.filter((selectedId) => selectedId !== id)
-      : [...selected, id];
+    const updatedSelected = selectedIds.includes(id)
+      ? selectedIds.filter((selectedId) => selectedId !== id)
+      : [...selectedIds, id];
 
-    setSelected(updatedSelected);
-
-    // disabled 처리를 위해 선택된 도장 길이 전달
-    onSelectedChange(updatedSelected?.length);
+    onSelectedChange(updatedSelected);
   };
 
   return (
@@ -68,7 +65,7 @@ const HoneyView = (props: HoneyViewProps) => {
                   content={letter.content}
                   imgUrl={letter.stampUrl}
                   date={letter.date}
-                  selected={selected.includes(letter.id)}
+                  selected={selectedIds.includes(letter.id)}
                   readOnly={!isSelectMode}
                   onClick={() => handleCheckHoneyStamp(letter.id)}
                 />

--- a/src/features/Stamp/components/Stamp/StampView/Honey/HoneyView.tsx
+++ b/src/features/Stamp/components/Stamp/StampView/Honey/HoneyView.tsx
@@ -59,7 +59,7 @@ const HoneyView = (props: HoneyViewProps) => {
               <>
                 <HoneyStamp
                   key={letter.id}
-                  profileImg=""
+                  profileImg={letter.profileImageUrl}
                   nameType={nameType}
                   name={letter.sender}
                   content={letter.content}

--- a/src/features/Stamp/components/Stamp/StampView/List/ListView.tsx
+++ b/src/features/Stamp/components/Stamp/StampView/List/ListView.tsx
@@ -47,7 +47,7 @@ const ListView = (props: ListViewProps) => {
       {letters.map((letter) => (
         <StampList
           key={letter.id}
-          profileImg=""
+          profileImg={letter.profileImageUrl}
           nameType={nameType}
           name={letter[nameType]}
           content={letter.content}

--- a/src/features/Stamp/components/Stamp/StampView/List/ListView.tsx
+++ b/src/features/Stamp/components/Stamp/StampView/List/ListView.tsx
@@ -47,6 +47,7 @@ const ListView = (props: ListViewProps) => {
       {letters.map((letter) => (
         <StampList
           key={letter.id}
+          id={letter.id}
           profileImg={letter.profileImageUrl}
           nameType={nameType}
           name={letter[nameType]}

--- a/src/features/Stamp/components/Stamp/StampView/List/ListView.tsx
+++ b/src/features/Stamp/components/Stamp/StampView/List/ListView.tsx
@@ -7,16 +7,16 @@ import { useLocation } from 'react-router-dom';
 interface ListViewProps {
   letters: HoneyLetter[];
   isSelectMode: boolean;
-  onSelectedChange: (count: number) => void;
+  selectedIds: number[];
+  onSelectedChange: (selectedIds: number[]) => void;
 }
 
 const ListView = (props: ListViewProps) => {
-  const { letters, isSelectMode, onSelectedChange } = props;
+  const { letters, isSelectMode, selectedIds, onSelectedChange } = props;
 
   const location = useLocation();
 
   const [nameType, setNameType] = useState<NameType>('sender');
-  const [selected, setSelected] = useState<number[]>([]);
 
   useEffect(() => {
     const urlParams = new URLSearchParams(location.search);
@@ -30,19 +30,16 @@ const ListView = (props: ListViewProps) => {
 
   useEffect(() => {
     if (!isSelectMode) {
-      setSelected([]);
+      onSelectedChange([]);
     }
-  }, [isSelectMode]);
+  }, [isSelectMode, onSelectedChange]);
 
-  const handleCheckStampList = (id: number) => {
-    const updatedSelected = selected.includes(id)
-      ? selected.filter((selectedId) => selectedId !== id)
-      : [...selected, id];
+  const handleCheckHoneyStamp = (id: number) => {
+    const updatedSelected = selectedIds.includes(id)
+      ? selectedIds.filter((selectedId) => selectedId !== id)
+      : [...selectedIds, id];
 
-    setSelected(updatedSelected);
-
-    // disabled 처리를 위해 선택된 도장 길이 전달
-    onSelectedChange(updatedSelected?.length);
+    onSelectedChange(updatedSelected);
   };
 
   return (
@@ -56,9 +53,9 @@ const ListView = (props: ListViewProps) => {
           content={letter.content}
           imgUrl={letter.stampUrl}
           date={letter.date}
-          selected={selected.includes(letter.id)}
+          selected={selectedIds.includes(letter.id)}
           readOnly={!isSelectMode}
-          onClick={() => handleCheckStampList(letter.id)}
+          onClick={() => handleCheckHoneyStamp(letter.id)}
         />
       ))}
     </ListViewContainer>

--- a/src/hooks/group/useGroupSearch.ts
+++ b/src/hooks/group/useGroupSearch.ts
@@ -1,19 +1,10 @@
-// import { handleMutationError } from '@/utils/error';
 import { useQuery } from '@tanstack/react-query';
-// import { useToast } from '@/store/useToast';
 import { getGroupSearch } from '@/api/group/getGroupSearch';
 
 export const useGroupSearch = (groupName: string) => {
-  // const { showToast } = useToast.getState();
 
   return useQuery(
     ['groupSearch', groupName],
     () => getGroupSearch({ groupName }),
-    // {
-    //   onError: (error) => {
-    //     handleMutationError(error);
-    //     showToast('그룹 검색에 실패했습니다.');
-    //   },
-    // }
   );
 };

--- a/src/hooks/group/usePatchReceiveGroupChange.ts
+++ b/src/hooks/group/usePatchReceiveGroupChange.ts
@@ -1,0 +1,17 @@
+import { useMutation } from '@tanstack/react-query';
+import { useToast } from '@/store/useToast';
+import { patchReceiveGroupChange } from '@/api/group/patchReceiveGroupChange';
+import { PatchGroupChange } from '@/api/group/types/Group';
+
+export const usePatchGroupOrder = () => {
+  const { showMoveToast } = useToast.getState();
+
+  return useMutation({
+    mutationKey: ['groupOrder'],
+    mutationFn: (patchData: PatchGroupChange) =>
+      patchReceiveGroupChange(patchData),
+    onSuccess: (patchData: PatchGroupChange) => {
+      showMoveToast('성공적으로 꿀을 옮겼어요.', `/group/${patchData.groupId}`);
+    },
+  });
+};

--- a/src/hooks/group/usePatchReceiveGroupChange.ts
+++ b/src/hooks/group/usePatchReceiveGroupChange.ts
@@ -1,17 +1,10 @@
 import { useMutation } from '@tanstack/react-query';
-import { useToast } from '@/store/useToast';
 import { patchReceiveGroupChange } from '@/api/group/patchReceiveGroupChange';
 import { PatchGroupChange } from '@/api/group/types/Group';
 
-export const usePatchGroupOrder = () => {
-  const { showMoveToast } = useToast.getState();
-
-  return useMutation({
-    mutationKey: ['groupOrder'],
-    mutationFn: (patchData: PatchGroupChange) =>
-      patchReceiveGroupChange(patchData),
-    onSuccess: (patchData: PatchGroupChange) => {
-      showMoveToast('성공적으로 꿀을 옮겼어요.', `/group/${patchData.groupId}`);
-    },
-  });
+export const usePatchReceiveGroupChange = () => {
+  return useMutation((patchGroupChange: PatchGroupChange) =>
+    patchReceiveGroupChange(patchGroupChange)
+  );
 };
+

--- a/src/hooks/group/usePatchSendGroupChange.ts
+++ b/src/hooks/group/usePatchSendGroupChange.ts
@@ -1,17 +1,9 @@
 import { useMutation } from '@tanstack/react-query';
-import { useToast } from '@/store/useToast';
-import { PatchGroupChange } from '@/api/group/types/Group';
 import { patchSendGroupChange } from '@/api/group/patchSendGroupChange';
+import { PatchGroupChange } from '@/api/group/types/Group';
 
 export const usePatchSendGroupChange = () => {
-  const { showMoveToast } = useToast.getState();
-
-  return useMutation({
-    mutationKey: ['groupOrder'],
-    mutationFn: (patchData: PatchGroupChange) =>
-      patchSendGroupChange(patchData),
-    onSuccess: (patchData: PatchGroupChange) => {
-      showMoveToast('성공적으로 꿀을 옮겼어요.', `/group/${patchData.groupId}`);
-    },
-  });
+  return useMutation(
+    (patchGroupChange: PatchGroupChange) => patchSendGroupChange(patchGroupChange),
+  );
 };

--- a/src/hooks/group/usePatchSendGroupChange.ts
+++ b/src/hooks/group/usePatchSendGroupChange.ts
@@ -1,0 +1,17 @@
+import { useMutation } from '@tanstack/react-query';
+import { useToast } from '@/store/useToast';
+import { PatchGroupChange } from '@/api/group/types/Group';
+import { patchSendGroupChange } from '@/api/group/patchSendGroupChange';
+
+export const usePatchSendGroupChange = () => {
+  const { showMoveToast } = useToast.getState();
+
+  return useMutation({
+    mutationKey: ['groupOrder'],
+    mutationFn: (patchData: PatchGroupChange) =>
+      patchSendGroupChange(patchData),
+    onSuccess: (patchData: PatchGroupChange) => {
+      showMoveToast('성공적으로 꿀을 옮겼어요.', `/group/${patchData.groupId}`);
+    },
+  });
+};

--- a/src/hooks/receivedPraise/useDeleteReceivedPraise.ts
+++ b/src/hooks/receivedPraise/useDeleteReceivedPraise.ts
@@ -1,12 +1,13 @@
 import { deleteReceivedPraise } from '@/api/receivedPraise/deleteReceivedPraise';
 import { useToast } from '@/store/useToast';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation} from '@tanstack/react-query';
 
 export const useDeleteReceivedPraise = () => {
   const { showToast } = useToast.getState();
-   return useMutation((ids: number[]) => deleteReceivedPraise(ids), {
-     onSuccess: () => {
+  
+  return useMutation((ids: number[]) => deleteReceivedPraise(ids), {
+    onSuccess: () => {
       showToast('선택한 꿀을 성공적으로 삭제하였습니다.');
-     },
-   });
+    },
+  });
 };

--- a/src/hooks/receivedPraise/useDeleteReceivedPraise.ts
+++ b/src/hooks/receivedPraise/useDeleteReceivedPraise.ts
@@ -1,6 +1,12 @@
 import { deleteReceivedPraise } from '@/api/receivedPraise/deleteReceivedPraise';
-import { useQuery } from '@tanstack/react-query';
+import { useToast } from '@/store/useToast';
+import { useMutation } from '@tanstack/react-query';
 
 export const useDeleteReceivedPraise = () => {
-  return useQuery(['receivedPraise'], () => deleteReceivedPraise());
+  const { showToast } = useToast.getState();
+   return useMutation((ids: number[]) => deleteReceivedPraise(ids), {
+     onSuccess: () => {
+      showToast('선택한 꿀을 성공적으로 삭제하였습니다.');
+     },
+   });
 };

--- a/src/hooks/receivedPraise/usePostReceivedPraise.ts
+++ b/src/hooks/receivedPraise/usePostReceivedPraise.ts
@@ -1,19 +1,10 @@
 import { PostReceivedPraise } from '@/api/receivedPraise/types/ReceivedPraise';
 import { postReceivedPraise } from '@/api/receivedPraise/postReceivedPraise';
 import { useMutation } from '@tanstack/react-query';
-// import { useToast } from '@/store/useToast';
-// import { handleMutationError } from '@/utils/error';
 
 export const usePostReceivedPraise = () => {
-  // const { showToast } = useToast.getState();
   
   return useMutation(
     (receivedPraise: PostReceivedPraise) => postReceivedPraise(receivedPraise),
-    {
-      // onError: (error) => {
-      //   handleMutationError(error);
-      //   showToast(`칭찬 저장에 실패했습니다. 다시 시도해주세요.`);
-      // },
-    }
   );
 };

--- a/src/layouts/FormLayoutStyles.ts
+++ b/src/layouts/FormLayoutStyles.ts
@@ -25,7 +25,7 @@ const ProgressBarWrapper = styled.div<{ marginBottom?: string }>`
 
 const CenterLayout = styled.div`
   width: 100%;
-  height: 100%;
+  height: 100vh;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/layouts/FormLayoutStyles.ts
+++ b/src/layouts/FormLayoutStyles.ts
@@ -36,7 +36,7 @@ const Container = styled.div`
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 40px;
+  gap: 48px;
 `;
 
 const Label = styled.div<LabelProps>`

--- a/src/pages/GuidePage.tsx
+++ b/src/pages/GuidePage.tsx
@@ -469,6 +469,7 @@ const GuidePage = () => {
         <Elements>
           <h4>Stamp List</h4>
           <StampList
+            id={0}
             profileImg={''}
             nameType={'sender'}
             name={'받는 사람'}
@@ -480,6 +481,7 @@ const GuidePage = () => {
             onClick={() => {}}
           />
           <StampList
+            id={0}
             profileImg={''}
             nameType={'receiver'}
             name={'보내는 사람'}
@@ -494,6 +496,7 @@ const GuidePage = () => {
         <Elements>
           <h4>Honey Stamp</h4>
           <HoneyStamp
+            id={0}
             profileImg={''}
             nameType={'receiver'}
             name={'sender'}

--- a/src/pages/compliment/send/ComplimentSendCompletePage.tsx
+++ b/src/pages/compliment/send/ComplimentSendCompletePage.tsx
@@ -1,5 +1,6 @@
 import Button from '@/components/Button/Button';
 import { BottomWrapper } from '@/layouts/FormLayoutStyles';
+import { useSendComplimentStore } from '@/store/useSendComplimentStore';
 import { theme } from '@/styles/theme';
 import styled from '@emotion/styled';
 import React from 'react';
@@ -7,17 +8,18 @@ import { useNavigate } from 'react-router-dom';
 
 const ComplimentSendCompletePage = () => {
   const navigate = useNavigate();
-  const receiver = '도도독사우르스';
+  const { receiverName, clearState } = useSendComplimentStore();
 
   const handleButtonClick = () => {
     navigate('/');
+    clearState();
   };
 
   return (
     <CenterLayout>
       <Image data="/assets/images/compliment/bongbong-complete.svg" />
       <Title>
-        `{receiver}`님에게
+        `{receiverName}`님에게
         <br /> 칭찬이 전달되었어요!
       </Title>
       <BottomWrapper>

--- a/src/pages/compliment/send/ComplimentSendContentPage.tsx
+++ b/src/pages/compliment/send/ComplimentSendContentPage.tsx
@@ -28,7 +28,6 @@ const ComplimentSendContentPage = () => {
     ongoing,
     honeyStampId,
     honeyStampImage,
-    clearState,
   } = useSendComplimentStore();
   const sender = getUserName() || '';
 
@@ -96,7 +95,6 @@ const ComplimentSendContentPage = () => {
             });
           }
 
-          clearState();
           navigate('/compliment/send/complete');
         },
       }

--- a/src/pages/compliment/send/ComplimentSendTargetPage.tsx
+++ b/src/pages/compliment/send/ComplimentSendTargetPage.tsx
@@ -13,7 +13,6 @@ import {
   ProgressBarWrapper,
 } from '@/layouts/FormLayoutStyles';
 import { useSendComplimentStore } from '@/store/useSendComplimentStore';
-import { theme } from '@/styles/theme';
 import styled from '@emotion/styled';
 import React, { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -32,6 +31,7 @@ const ComplimentSendTargetPage = () => {
     setOngoing,
     clearState,
   } = useSendComplimentStore();
+  const [errorMsg, setErrorMsg] = useState<string>('');
   const [showGroupModal, setShowGroupModal] = useState<boolean>(false);
   const [selectedGroup, setSelectedGroup] = useState<number | null>(null);
 
@@ -49,7 +49,12 @@ const ComplimentSendTargetPage = () => {
   }, [receiverName, groupName, ongoing]);
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setReceiverName(e.target.value);
+    if (e.target.value.length <= 8) {
+      setReceiverName(e.target.value);
+      setErrorMsg('');
+    } else {
+      setErrorMsg('8자 이내로 입력해 주세요.');
+    }
   };
 
   const handleGroupChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -93,20 +98,19 @@ const ComplimentSendTargetPage = () => {
           <Label marginBottom="4px" typography="subtitle1">
             칭찬하고 싶은 팀원의 이름을 적어주세요.
           </Label>
-          <Description>본명을 적어주세요.</Description>
           <Input
             width="100%"
             placeholder="ex. 도도독사우루스"
             clear={true}
             value={receiverName}
             onChange={handleNameChange}
+            errorMsg={errorMsg}
           />
         </LabelWrapper>
         <LabelWrapper>
           <Label marginBottom="4px" typography="subtitle1">
             함께하고 있는 그룹명을 적어주세요.
           </Label>
-          <Description>그룹명은 추후에 수정할 수 있어요.</Description>
           <Input
             width="100%"
             placeholder="ex. 꿀단지 만들기 프로젝트"
@@ -119,7 +123,7 @@ const ComplimentSendTargetPage = () => {
         </LabelWrapper>
         <LabelWrapper>
           <Label marginBottom="14px" typography="subtitle1">
-            해당 프로젝트는 현재 진행 중인가요?
+            함께 그룹 활동을 진행하는 중인가요?
           </Label>
           <CheckList>
             {CHECK_COMPLIMENT_OPTIONS.map((option) => (
@@ -172,11 +176,6 @@ const LabelWrapper = styled.div`
   flex-direction: column;
 `;
 
-const Description = styled.div`
-  color: ${theme.colors.gray50};
-  ${theme.typography.body4};
-  margin-bottom: 14px;
-`;
 const CheckList = styled.div`
   width: 100%;
   display: flex;

--- a/src/pages/group/GroupDetailPage.tsx
+++ b/src/pages/group/GroupDetailPage.tsx
@@ -16,6 +16,7 @@ import EditGroupNameModal from '@/features/Group/components/Modal/EditGroupNameM
 import StampCard from '@/features/Stamp/components/Stamp/StampCard';
 import { useGroupDetail } from '@/hooks/group/useGroupDetail';
 import { usePatchGroup } from '@/hooks/group/usePatchGroup';
+import { useDeleteReceivedPraise } from '@/hooks/receivedPraise/useDeleteReceivedPraise';
 import { useGroupReceivedPraise } from '@/hooks/receivedPraise/useGroupReceivedPraise';
 import { useGroupSendPraise } from '@/hooks/sendPraise/useGroupSendPraise';
 import { useReceiveStamp } from '@/hooks/stamp/useReceiveStamp';
@@ -59,6 +60,7 @@ const GroupDetailPage = () => {
   const [selectedDisplay, setSelectedDisplay] = useState<ToggleType>('honey');
   const { data: groupInfo } = useGroupDetail(parseInt(id || '0'));
   const { data: totalStamp } = useReceiveStamp(parseInt(id || '0'));
+  const { mutate: deletePraise } = useDeleteReceivedPraise();
   const totalStampList = totalStamp?.stampInfoByGroupDtos || [];
   const initGroupName = groupInfo?.groupName;
   const [groupName, setGroupName] = useState<string>(initGroupName || '');
@@ -170,7 +172,10 @@ const GroupDetailPage = () => {
 
   const handleHoneyDelete = () => {
     // 꿀 삭제하기
-    console.log(selectedIds);
+    if (selectedIds.length > 0) {
+      deletePraise(selectedIds);
+      console.log('삭제된 꿀: ', selectedIds);
+    }
   };
 
   /* 꿀 상세보기 관련 함수*/
@@ -297,23 +302,25 @@ const GroupDetailPage = () => {
               disabled={selectedIds.length === 0}
               onClick={handleHoneyMove}
             />
-            <Button
-              text=""
-              variant="activate"
-              icon={
-                <img
-                  src="/assets/icons/trash.svg"
-                  width={28}
-                  height={28}
-                  alt="삭제"
-                />
-              }
-              width="54px"
-              height="54px"
-              background={theme.colors.warning90}
-              disabled={selectedIds.length === 0}
-              onClick={handleHoneyDelete}
-            />
+            {tabValue === 'receive' && (
+              <Button
+                text=""
+                variant="activate"
+                icon={
+                  <img
+                    src="/assets/icons/trash.svg"
+                    width={28}
+                    height={28}
+                    alt="삭제"
+                  />
+                }
+                width="54px"
+                height="54px"
+                background={theme.colors.warning90}
+                disabled={selectedIds.length === 0}
+                onClick={handleHoneyDelete}
+              />
+            )}
           </SelectActionButtonWrapper>
         )}
         {/* 꿀 옮기기 그룹 선택 모달 */}

--- a/src/pages/group/GroupDetailPage.tsx
+++ b/src/pages/group/GroupDetailPage.tsx
@@ -254,12 +254,26 @@ const GroupDetailPage = () => {
       console.log(patchData);
       sendGroupChange(patchData, {
         onSuccess: () => {
+          setLetters((prevLetters) =>
+            prevLetters.filter((letter) => !selectedIds.includes(letter.id))
+          );
+
+          // 받은 꿀과 보낸 꿀 갯수 업데이트
+          refetchReceivedPraise();
+          refetchSendPraise();
           showMoveToast('성공적으로 꿀을 옮겼어요.', `/group/${selectedGroup}`);
         },
       });
     } else if (tabValue === 'receive') {
       receiveGroupChange(patchData, {
         onSuccess: () => {
+          setLetters((prevLetters) =>
+            prevLetters.filter((letter) => !selectedIds.includes(letter.id))
+          );
+
+          // 받은 꿀과 보낸 꿀 갯수 업데이트
+          refetchReceivedPraise();
+          refetchSendPraise();
           showMoveToast('성공적으로 꿀을 옮겼어요.', `/group/${selectedGroup}`);
         },
       });
@@ -284,7 +298,6 @@ const GroupDetailPage = () => {
           setLetters((prevLetters) =>
             prevLetters.filter((letter) => !selectedIds.includes(letter.id))
           );
-          console.log('삭제된 꿀: ', selectedIds);
 
           // 받은 꿀과 보낸 꿀 갯수 업데이트
           refetchReceivedPraise();
@@ -304,12 +317,14 @@ const GroupDetailPage = () => {
     closeDetailModal();
   };
 
-  const handleShowHoneyMoveModal = () => {
+  /* 꿀 상세보기 > 꿀 옮기기 */
+  const handleShowHoneyMoveModal = (id: number) => {
+    setSelectedIds([id]);
     setHoneyMoveModalOpen(true);
     closeDetailModal();
   };
 
-  // 삭제 경고 모달 추가
+  /* 꿀 상세보기 > 꿀 삭제하기 */
   const handleShowHoneyDeleteModal = (id: number) => {
     deletePraise([id], {
       onSuccess: () => {
@@ -317,7 +332,11 @@ const GroupDetailPage = () => {
         setLetters((prevLetters) =>
           prevLetters.filter((letter) => !selectedIds.includes(letter.id))
         );
-        console.log('삭제된 꿀: ', selectedIds);
+
+        // 받은 꿀과 보낸 꿀 갯수 업데이트
+        refetchReceivedPraise();
+        refetchSendPraise();
+
         closeDetailModal();
       },
     });
@@ -494,7 +513,9 @@ const GroupDetailPage = () => {
           stampImage={modalContent.imgUrl}
           onConfirm={handleSaveDetailHoney}
           onClose={handleCloseDetailHoney}
-          onHoneyMove={handleShowHoneyMoveModal}
+          onHoneyMove={() => {
+            handleShowHoneyMoveModal(modalContent.id);
+          }}
           onHoneyDelete={() => {
             handleShowHoneyDeleteModal(modalContent.id);
           }}

--- a/src/pages/group/GroupDetailPage.tsx
+++ b/src/pages/group/GroupDetailPage.tsx
@@ -1,3 +1,4 @@
+import { PatchGroupChange } from '@/api/group/types/Group';
 import { GroupReceivePraiseInfo } from '@/api/receivedPraise/types/ReceivedPraise';
 import { GroupSendPraiseInfo } from '@/api/sendPraise/types/SendPraise';
 import BottomSheet from '@/components/BottomSheet/BottomSheet';
@@ -19,6 +20,8 @@ import EditGroupNameModal from '@/features/Group/components/Modal/EditGroupNameM
 import StampCard from '@/features/Stamp/components/Stamp/StampCard';
 import { useGroupDetail } from '@/hooks/group/useGroupDetail';
 import { usePatchGroup } from '@/hooks/group/usePatchGroup';
+import { usePatchReceiveGroupChange } from '@/hooks/group/usePatchReceiveGroupChange';
+import { usePatchSendGroupChange } from '@/hooks/group/usePatchSendGroupChange';
 import { useDeleteReceivedPraise } from '@/hooks/receivedPraise/useDeleteReceivedPraise';
 import { useGroupReceivedPraise } from '@/hooks/receivedPraise/useGroupReceivedPraise';
 import { useGroupSendPraise } from '@/hooks/sendPraise/useGroupSendPraise';
@@ -33,11 +36,11 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 const GroupDetailPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
+  const { showMoveToast } = useToast();
   /* 그룹 ID, 페이지 크기 */
   const { id } = useParams();
   const groupId = Number(id) || 0;
   const pageSize = 10;
-  const { showMoveToast } = useToast();
   const { isDetailModalOpen, modalContent, closeDetailModal } =
     useDetailHoneyModalStore();
 
@@ -56,6 +59,9 @@ const GroupDetailPage = () => {
       size: 10,
       page: 0,
     });
+
+  const { mutate: sendGroupChange } = usePatchSendGroupChange();
+  const { mutate: receiveGroupChange } = usePatchReceiveGroupChange();
 
   /* 보낸 꿀, 받은 꿀 탭 */
   const searchParams = new URLSearchParams(location.search);
@@ -80,16 +86,18 @@ const GroupDetailPage = () => {
   const [isSelectMode, setIsSelectMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
 
-  /* 모달 */
+  /* 꿀 옮기기 모달 */
   const [isHoneyMoveModalOpen, setHoneyMoveModalOpen] = useState(false);
   const [selectedGroup, setSelectedGroup] = useState<number | null>(null);
   const [isHoneyMoveCheckModalOpen, setHoneyMoveCheckModalOpen] =
     useState(false);
-
   const [showCancelModal, setShowCancelModal] = useState<boolean>(false);
+
+  /* 그룹명 편집 모달 */
   const [showEditGroupNameModal, setShowEditGroupNameModal] =
     useState<boolean>(false);
 
+  /* 받은 꿀 저장 완료 모달 */
   const [showToastModal, setShowToastModal] = useState<boolean>(false);
 
   /* React Query 호출 */
@@ -235,13 +243,30 @@ const GroupDetailPage = () => {
     setSelectedGroup(null);
   };
 
+  /* 꿀 옮기기 */
   const handleHoneyMoveCheckModalConfirm = async () => {
-    // 꿀 옮기기 API
+    const patchData: PatchGroupChange = {
+      praiseIdList: selectedIds,
+      groupId: selectedGroup || 0,
+    };
+
+    if (tabValue === 'send') {
+      console.log(patchData);
+      sendGroupChange(patchData, {
+        onSuccess: () => {
+          showMoveToast('성공적으로 꿀을 옮겼어요.', `/group/${selectedGroup}`);
+        },
+      });
+    } else if (tabValue === 'receive') {
+      receiveGroupChange(patchData, {
+        onSuccess: () => {
+          showMoveToast('성공적으로 꿀을 옮겼어요.', `/group/${selectedGroup}`);
+        },
+      });
+    }
+
     setHoneyMoveCheckModalOpen(false);
     handleCandleHoneyMove();
-    setIsSelectMode(false);
-    // 꿀 옮기기 성공 시 토스트 메세지
-    showMoveToast('성공적으로 꿀을 옮겼어요', `/group/${selectedGroup}`);
   };
 
   /* 꿀 옮기기 취소 관련 함수 */

--- a/src/pages/group/GroupDetailPage.tsx
+++ b/src/pages/group/GroupDetailPage.tsx
@@ -1,3 +1,5 @@
+import { GroupReceivePraiseInfo } from '@/api/receivedPraise/types/ReceivedPraise';
+import { GroupSendPraiseInfo } from '@/api/sendPraise/types/SendPraise';
 import BottomSheet from '@/components/BottomSheet/BottomSheet';
 import Button from '@/components/Button/Button';
 import SelectButton from '@/components/Button/SelectButton';
@@ -11,6 +13,7 @@ import TabToggle from '@/components/Toggle/TabToggle';
 import DetailHoneyModal from '@/features/Compliment/components/Modal/DetailHoneyModal';
 import HoneyMoveCheckModal from '@/features/Compliment/components/Modal/HoneyMoveCheckModal';
 import HoneyMoveModal from '@/features/Compliment/components/Modal/HoneyMoveModal';
+import { HoneyLetter } from '@/features/Compliment/types/HoneyLetter';
 import GroupTabContainer from '@/features/Group/components/Container/GroupTabContainer';
 import EditGroupNameModal from '@/features/Group/components/Modal/EditGroupNameModal';
 import StampCard from '@/features/Stamp/components/Stamp/StampCard';
@@ -24,51 +27,60 @@ import { useDetailHoneyModalStore } from '@/store/useDetailHoneyModalStore';
 import { useToast } from '@/store/useToast';
 import { theme } from '@/styles/theme';
 import styled from '@emotion/styled';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 const GroupDetailPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
+  /* 그룹 ID, 페이지 크기 */
   const { id } = useParams();
+  const groupId = Number(id) || 0;
+  const pageSize = 10;
   const { showMoveToast } = useToast();
   const { isDetailModalOpen, modalContent, closeDetailModal } =
     useDetailHoneyModalStore();
-  const searchParams = new URLSearchParams(location.search);
-  const tabValue = searchParams.get('tab') || 'send';
 
-  const { data: receivedPraiseData } = useGroupReceivedPraise({
-    groupId: parseInt(id || '0'),
-    size: 10,
-    page: 0,
-  });
-
-  const { data: sendPraiseData } = useGroupSendPraise({
-    groupId: parseInt(id || '0'),
-    size: 10,
-    page: 0,
-  });
-
-  const receivedPraiseCount = receivedPraiseData
-    ? receivedPraiseData.pages[0].pageInfo.totalElements
-    : 0;
-
-  const sendPraiseCount = sendPraiseData
-    ? sendPraiseData.pages[0].pageInfo.totalElements
-    : 0;
-
-  const [selectedDisplay, setSelectedDisplay] = useState<ToggleType>('honey');
   const { data: groupInfo } = useGroupDetail(parseInt(id || '0'));
   const { data: totalStamp } = useReceiveStamp(parseInt(id || '0'));
   const { mutate: deletePraise } = useDeleteReceivedPraise();
+  const { data: receivedPraiseData, refetch: refetchReceivedPraise } =
+    useGroupReceivedPraise({
+      groupId: parseInt(id || '0'),
+      size: 10,
+      page: 0,
+    });
+  const { data: sendPraiseData, refetch: refetchSendPraise } =
+    useGroupSendPraise({
+      groupId: parseInt(id || '0'),
+      size: 10,
+      page: 0,
+    });
+
+  /* 보낸 꿀, 받은 꿀 탭 */
+  const searchParams = new URLSearchParams(location.search);
+  const tabValue = searchParams.get('tab') || 'send';
+
+  /* 받은 꿀, 보낸 꿀 갯수 */
+  const [receivedPraiseCount, setReceivedPraiseCount] = useState<number>(0);
+  const [sendPraiseCount, setSendPraiseCount] = useState<number>(0);
+
+  const [letters, setLetters] = useState<HoneyLetter[]>([]);
+
+  /* 보기 탭 */
+  const [selectedDisplay, setSelectedDisplay] = useState<ToggleType>('honey');
   const totalStampList = totalStamp?.stampInfoByGroupDtos || [];
   const initGroupName = groupInfo?.groupName;
   const [groupName, setGroupName] = useState<string>(initGroupName || '');
   const praiseCount = groupInfo?.praiseCount;
 
+  const title = `${groupInfo?.groupName || ''} (${praiseCount || 0})`;
+
+  /* 선택 모드 및 선택한 id 배열 */
   const [isSelectMode, setIsSelectMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
 
+  /* 모달 */
   const [isHoneyMoveModalOpen, setHoneyMoveModalOpen] = useState(false);
   const [selectedGroup, setSelectedGroup] = useState<number | null>(null);
   const [isHoneyMoveCheckModalOpen, setHoneyMoveCheckModalOpen] =
@@ -80,6 +92,80 @@ const GroupDetailPage = () => {
 
   const [showToastModal, setShowToastModal] = useState<boolean>(false);
 
+  /* React Query 호출 */
+  const queryHook =
+    tabValue === 'receive'
+      ? useGroupReceivedPraise({
+          groupId,
+          size: pageSize,
+          page: 0,
+        })
+      : tabValue === 'send'
+        ? useGroupSendPraise({
+            groupId,
+            size: pageSize,
+            page: 0,
+          })
+        : null;
+
+  const data = queryHook?.data;
+  const fetchNextPage = queryHook?.fetchNextPage;
+  const hasNextPage = queryHook?.hasNextPage;
+  const isFetching = queryHook?.isFetching;
+
+  /* 페이지 끝까지 데이터 가져오기 */
+  useEffect(() => {
+    if (hasNextPage && !isFetching) {
+      fetchNextPage?.();
+    }
+  }, [hasNextPage, isFetching]);
+
+  useEffect(() => {
+    if (tabValue === 'send') {
+      setLetters(
+        data
+          ? data.pages.flatMap((page) =>
+              (page as GroupSendPraiseInfo).sendPraiseInfos.map((praise) => ({
+                id: praise.sendPraiseId,
+                sender: praise.name,
+                receiver: praise.name,
+                content: praise.content,
+                stampUrl: praise.stampUrl,
+                profileImageUrl: praise.profileImageUrl,
+                date: praise.sendDate,
+              }))
+            )
+          : []
+      );
+    } else if (tabValue === 'receive') {
+      setLetters(
+        data
+          ? data.pages.flatMap((page) =>
+              (page as GroupReceivePraiseInfo).receivePraiseInfos.map(
+                (praise) => ({
+                  id: praise.receivePraiseId,
+                  sender: praise.name,
+                  receiver: praise.name,
+                  content: praise.content,
+                  stampUrl: praise.stampUrl,
+                  profileImageUrl: praise.profileImageUrl,
+                  date: praise.receiveDate,
+                })
+              )
+            )
+          : []
+      );
+    }
+  }, [tabValue, data]);
+
+  useEffect(() => {
+    setReceivedPraiseCount(
+      receivedPraiseData?.pages[0].pageInfo.totalElements || 0
+    );
+    setSendPraiseCount(sendPraiseData?.pages[0].pageInfo.totalElements || 0);
+  }, [receivedPraiseData, sendPraiseData]);
+
+  /* 받은 꿀 저장 완료 안내 모달 */
   useEffect(() => {
     if (location.state?.showToast) {
       setShowToastModal(true);
@@ -89,7 +175,7 @@ const GroupDetailPage = () => {
 
       return () => clearTimeout(timer);
     }
-  }, [location.state]);
+  }, [location.state?.showToast]);
 
   const handleToggle = () => {
     if (isSelectMode && selectedIds.length > 0) {
@@ -98,8 +184,6 @@ const GroupDetailPage = () => {
       setIsSelectMode(!isSelectMode);
     }
   };
-
-  const title = `${groupInfo?.groupName || ''} (${praiseCount || 0})`;
 
   const handleShowEditModal = () => {
     setShowEditGroupNameModal(true);
@@ -125,11 +209,8 @@ const GroupDetailPage = () => {
   };
 
   const handleWriteCompliment = () => {
-    // 칭찬 작성하기 페이지 이동
     navigate('/compliment/send/target');
   };
-
-  useEffect(() => {}, [isSelectMode]);
 
   /* 꿀 옮기기 프로세스 관련 함수 */
   const handleHoneyMove = () => {
@@ -158,9 +239,8 @@ const GroupDetailPage = () => {
     // 꿀 옮기기 API
     setHoneyMoveCheckModalOpen(false);
     handleCandleHoneyMove();
-
+    setIsSelectMode(false);
     // 꿀 옮기기 성공 시 토스트 메세지
-
     showMoveToast('성공적으로 꿀을 옮겼어요', `/group/${selectedGroup}`);
   };
 
@@ -170,11 +250,22 @@ const GroupDetailPage = () => {
     setIsSelectMode(false);
   };
 
+  /* 꿀 삭제하기 */
   const handleHoneyDelete = () => {
-    // 꿀 삭제하기
     if (selectedIds.length > 0) {
-      deletePraise(selectedIds);
-      console.log('삭제된 꿀: ', selectedIds);
+      deletePraise(selectedIds, {
+        onSuccess: () => {
+          setIsSelectMode(false);
+          setLetters((prevLetters) =>
+            prevLetters.filter((letter) => !selectedIds.includes(letter.id))
+          );
+          console.log('삭제된 꿀: ', selectedIds);
+
+          // 받은 꿀과 보낸 꿀 갯수 업데이트
+          refetchReceivedPraise();
+          refetchSendPraise();
+        },
+      });
     }
   };
 
@@ -193,13 +284,27 @@ const GroupDetailPage = () => {
     closeDetailModal();
   };
 
-  const handleShowHoneyDeleteModal = () => {
-    closeDetailModal();
+  // 삭제 경고 모달 추가
+  const handleShowHoneyDeleteModal = (id: number) => {
+    deletePraise([id], {
+      onSuccess: () => {
+        setIsSelectMode(false);
+        setLetters((prevLetters) =>
+          prevLetters.filter((letter) => !selectedIds.includes(letter.id))
+        );
+        console.log('삭제된 꿀: ', selectedIds);
+        closeDetailModal();
+      },
+    });
   };
 
   const handleTabClick = (id: string) => {
     navigate(`/group/${id}?tab=${id}`, { replace: true });
   };
+
+  const onSelectedChange = useCallback((ids: number[]) => {
+    setSelectedIds(ids);
+  }, []);
 
   return (
     <Layout>
@@ -287,11 +392,11 @@ const GroupDetailPage = () => {
           />
         </DisplayToggleWrapper>
         <GroupTabContainer
-          type={tabValue === 'send' ? 'send' : 'receive'}
           displayType={selectedDisplay}
           isSelectMode={isSelectMode}
           selectedIds={selectedIds}
-          onSelectedChange={(ids: number[]) => setSelectedIds(ids)}
+          onSelectedChange={onSelectedChange}
+          letters={letters}
         />
         {/* 꿀 이동 및 삭제 버튼 */}
         {isSelectMode && (
@@ -365,7 +470,9 @@ const GroupDetailPage = () => {
           onConfirm={handleSaveDetailHoney}
           onClose={handleCloseDetailHoney}
           onHoneyMove={handleShowHoneyMoveModal}
-          onHoneyDelete={handleShowHoneyDeleteModal}
+          onHoneyDelete={() => {
+            handleShowHoneyDeleteModal(modalContent.id);
+          }}
         />
       )}
       {/* 꿀 저장 성공 모달*/}

--- a/src/pages/group/GroupDetailPage.tsx
+++ b/src/pages/group/GroupDetailPage.tsx
@@ -65,7 +65,7 @@ const GroupDetailPage = () => {
   const praiseCount = groupInfo?.praiseCount;
 
   const [isSelectMode, setIsSelectMode] = useState(false);
-  const [selectedCount, setSelectedCount] = useState<number>(0);
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
 
   const [isHoneyMoveModalOpen, setHoneyMoveModalOpen] = useState(false);
   const [selectedGroup, setSelectedGroup] = useState<number | null>(null);
@@ -90,7 +90,7 @@ const GroupDetailPage = () => {
   }, [location.state]);
 
   const handleToggle = () => {
-    if (isSelectMode && selectedCount > 0) {
+    if (isSelectMode && selectedIds.length > 0) {
       setShowCancelModal(true);
     } else {
       setIsSelectMode(!isSelectMode);
@@ -166,6 +166,11 @@ const GroupDetailPage = () => {
   const handleCandleHoneyMove = () => {
     setShowCancelModal(false);
     setIsSelectMode(false);
+  };
+
+  const handleHoneyDelete = () => {
+    // 꿀 삭제하기
+    console.log(selectedIds);
   };
 
   /* 꿀 상세보기 관련 함수*/
@@ -280,7 +285,8 @@ const GroupDetailPage = () => {
           type={tabValue === 'send' ? 'send' : 'receive'}
           displayType={selectedDisplay}
           isSelectMode={isSelectMode}
-          onSelectedChange={(count: number) => setSelectedCount(count)}
+          selectedIds={selectedIds}
+          onSelectedChange={(ids: number[]) => setSelectedIds(ids)}
         />
         {/* 꿀 이동 및 삭제 버튼 */}
         {isSelectMode && (
@@ -288,7 +294,7 @@ const GroupDetailPage = () => {
             <Button
               text="다른 그룹으로 꿀 옮기기"
               variant="warning"
-              disabled={selectedCount === 0}
+              disabled={selectedIds.length === 0}
               onClick={handleHoneyMove}
             />
             <Button
@@ -305,7 +311,8 @@ const GroupDetailPage = () => {
               width="54px"
               height="54px"
               background={theme.colors.warning90}
-              disabled={selectedCount === 0}
+              disabled={selectedIds.length === 0}
+              onClick={handleHoneyDelete}
             />
           </SelectActionButtonWrapper>
         )}
@@ -325,7 +332,7 @@ const GroupDetailPage = () => {
           onConfirm={handleHoneyMoveCheckModalConfirm}
           selectedGroup={selectedGroup}
           groupId={Number(id)}
-          selectedCount={selectedCount}
+          selectedCount={selectedIds.length}
         />
         {showCancelModal && (
           <WarningModal

--- a/src/pages/group/GroupDetailPage.tsx
+++ b/src/pages/group/GroupDetailPage.tsx
@@ -1,5 +1,3 @@
-import { GroupReceivePraiseInfo } from '@/api/receivedPraise/types/ReceivedPraise';
-import { GroupSendPraiseInfo } from '@/api/sendPraise/types/SendPraise';
 import BottomSheet from '@/components/BottomSheet/BottomSheet';
 import Button from '@/components/Button/Button';
 import SelectButton from '@/components/Button/SelectButton';
@@ -51,15 +49,11 @@ const GroupDetailPage = () => {
   });
 
   const receivedPraiseCount = receivedPraiseData
-    ? receivedPraiseData.pages.flatMap(
-        (page) => (page as GroupReceivePraiseInfo).receivePraiseInfos
-      ).length
+    ? receivedPraiseData.pages[0].pageInfo.totalElements
     : 0;
 
   const sendPraiseCount = sendPraiseData
-    ? sendPraiseData.pages.flatMap(
-        (page) => (page as GroupSendPraiseInfo).sendPraiseInfos
-      ).length
+    ? sendPraiseData.pages[0].pageInfo.totalElements
     : 0;
 
   const [selectedDisplay, setSelectedDisplay] = useState<ToggleType>('honey');

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -90,9 +90,9 @@ const router = createBrowserRouter([
             children: [
               { path: 'target', element: <ComplimentSendTargetPage /> },
               { path: 'content', element: <ComplimentSendContentPage /> },
-              { path: 'complete', element: <ComplimentSendCompletePage /> },
             ],
           },
+          { path: 'send/complete', element: <ComplimentSendCompletePage /> },
           {
             path: 'receive',
             element: <SubLayout title="칭찬 받기" />,
@@ -119,9 +119,9 @@ const router = createBrowserRouter([
       { path: 'name', element: <SignUpNamePage /> },
       { path: 'email', element: <SignUpEmailPage /> },
       { path: 'profile', element: <SignUpProfilePage /> },
-      { path: 'complete', element: <SignUpCompletePage /> },
     ],
   },
+  { path: 'signup/complete', element: <SignUpCompletePage /> },
   { path: '*', element: <Navigate to="/login" replace /> },
 ]);
 

--- a/src/store/useDetailHoneyModalStore.tsx
+++ b/src/store/useDetailHoneyModalStore.tsx
@@ -3,6 +3,7 @@ import { create } from 'zustand';
 interface DetailHoneyModalState {
   isDetailModalOpen: boolean;
   modalContent: {
+    id: number;
     profileImg: string;
     nameType: 'receiver' | 'sender';
     name: string;
@@ -18,6 +19,7 @@ export const useDetailHoneyModalStore = create<DetailHoneyModalState>(
   (set) => ({
     isDetailModalOpen: false,
     modalContent: {
+      id: 0,
       profileImg: '',
       nameType: 'sender',
       name: '',


### PR DESCRIPTION
## 연관 이슈

DD-141

<br/>

## 개요

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요. -->
꿀 옮기기 및 꿀 삭제 API 연동
<br/>

## ✅ 작업 내용

- [x] 토큰 재발급 API 오류 수정
- [x] QA 내용 반영
- [x] 그룹 내부 받은 꿀, 보낸 꿀 개수 오류 수정
- [x] letter 데이터 상위 페이지에서 받아오도록 변경
- [x] 그룹 내 받은 꿀, 보낸 꿀 조회 API 프로필 이미지 응답값 추가
- [x] 꿀 옮기기 API 연동
- [x] 꿀 삭제 API 연동
- [x] 콘솔 오류 수정 등

<br/>

## 🖥 구현 결과

<!--  구현한 기능이 보이는 스크린샷을 업로드해주세요. -->

<br/>


### 📝 기타 사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업 등을 적어주세요. -->
<br/>

<br/>
