### PR TITLE
[Feat] 로그인 안 됐을 때 이동하는 페이지

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -100,13 +100,6 @@ const router = createBrowserRouter([
           },
         ],
       },
-      {
-        path: '/',
-        element: <YellowBackgroundLayout />,
-        children: [
-          { path: 'compliment/:id', element: <ComplimentDetailPage /> },
-        ],
-      },
     ],
   },
   { path: 'login', element: <LoginPage /> },
@@ -122,6 +115,11 @@ const router = createBrowserRouter([
     ],
   },
   { path: 'signup/complete', element: <SignUpCompletePage /> },
+  {
+    path: '/',
+    element: <YellowBackgroundLayout />,
+    children: [{ path: 'compliment/:id', element: <ComplimentDetailPage /> }],
+  },
   { path: '*', element: <Navigate to="/login" replace /> },
 ]);
 


### PR DESCRIPTION
## 연관 이슈

DD-133

<br/>

## 개요
로그인이 안 된 상태면, 회원가입 프로세스, 로그인, 칭찬 받기 페이지를 제외하고
`/login` 경로로 이동하게 만들었습니다.

로그인 안 됐을 때 이동하는 페이지에 ComplimentDetailPage 추가했습니다.
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요. -->

<br/>

## ✅ 작업 내용

- [ ] 로그인 안 됐을 때 이동하는 페이지에 ComplimentDetailPage 추가

<br/>

## 🖥 구현 결과
![image](https://github.com/user-attachments/assets/17ec1e2a-f773-4899-9bdb-d4e43760b405)

<!--  구현한 기능이 보이는 스크린샷을 업로드해주세요. -->

<br/>

### 리뷰 요구사항

<!-- 리뷰 시에 유심히 봐주었으면 하는 부분이 있다면 설명해주세요. -->

<br/>

### 📝 기타 사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업 등을 적어주세요. -->
<br/>

<br/>
