### PR TITLE
[Fix] 2차 QA 

### DIFF
--- a/src/components/Button/BackButton.tsx
+++ b/src/components/Button/BackButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import styled from '@emotion/styled';
 
 interface BackButtonProps {
@@ -8,15 +8,21 @@ interface BackButtonProps {
   children?: React.ReactNode;
 }
 
-const BackButton: React.FC<BackButtonProps> = ({ to, onClick, children }) => {
+const BackButton: React.FC<BackButtonProps> = ({ to, children }) => {
   const navigate = useNavigate();
+  const location = useLocation();
+  const double = location.state?.double;
 
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
-    if (onClick) {
-      onClick(e);
-    } else if (!to) {
+    if (to) {
+      navigate(to);
+    } else {
       e.preventDefault();
-      navigate(-1);
+      if (double) {
+        navigate(-2);
+      } else {
+        navigate(-1);
+      }
     }
   };
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -70,7 +70,7 @@ const StyledButton = styled.button<ButtonProps>`
         case 'danger':
           return props.theme.colors.error90;
         case 'warning':
-          return props.theme.colors.warning20;
+          return props.theme.colors.warning90;
         default:
           return;
       }

--- a/src/components/Header/BackHeader.tsx
+++ b/src/components/Header/BackHeader.tsx
@@ -6,14 +6,15 @@ import BackButton from '../Button/BackButton';
 interface BackHeaderProps {
   title: string;
   children?: React.ReactNode;
+  to?: string;
 }
 
 const BackHeader = (props: BackHeaderProps) => {
-  const { title, children } = props;
+  const { title, children, to } = props;
 
   return (
     <Header>
-      <BackButton />
+      <BackButton to={to} />
       <Title>{title}</Title>
       {children}
     </Header>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -18,7 +18,7 @@ const Header = ({ onMenuClick }: HeaderProps) => {
           height={20}
           alt="header-logo"
           onClick={() => {
-            navigate('/');
+            navigate('/', { replace: true });
           }}
         />
       </LogoWrapper>
@@ -28,7 +28,7 @@ const Header = ({ onMenuClick }: HeaderProps) => {
             src="/assets/icons/profile.svg"
             alt="header-profile"
             onClick={() => {
-              navigate('/profile');
+              navigate('/profile', { replace: true });
             }}
           />
         </IconWrapper>

--- a/src/constants/menu.ts
+++ b/src/constants/menu.ts
@@ -8,7 +8,6 @@ export const MENU: MenuItem[] = [
       { id: 0, subTitle: '나의 꿀단지 Main', path: '/' },
       { id: 1, subTitle: '그룹 관리', path: '/group/management' },
       { id: 2, subTitle: '프로필 수정', path: '/profile/update' },
-      { id: 3, subTitle: '서비스 이용 약관', path: '/setting/terms' },
     ],
   },
   {

--- a/src/features/Group/components/Modal/EditGroupNameModal.tsx
+++ b/src/features/Group/components/Modal/EditGroupNameModal.tsx
@@ -90,7 +90,7 @@ const EditGroupNameModal: React.FC<EditGroupNameModalProps> = ({
     groupDelete(groupId + '');
     setShowGroupDeleteModal(false);
     showToast('그룹을 삭제했어요');
-    navigate('/group/management');
+    navigate('/group/management', { state: { double: true }, replace: true });
   };
 
   return (

--- a/src/features/Group/components/Modal/EditGroupNameModal.tsx
+++ b/src/features/Group/components/Modal/EditGroupNameModal.tsx
@@ -42,6 +42,10 @@ const EditGroupNameModal: React.FC<EditGroupNameModalProps> = ({
   });
 
   useEffect(() => {
+    setEditGroupName(groupName);
+  }, []);
+
+  useEffect(() => {
     if (editGroupName.trim() !== '') {
       checkGroupName();
     }

--- a/src/features/Main/components/HoneyGroup.tsx
+++ b/src/features/Main/components/HoneyGroup.tsx
@@ -6,6 +6,7 @@ import Button from '@/components/Button/Button';
 import GroupPagination from './GroupPagination';
 import { useNavigate } from 'react-router-dom';
 import { GroupWithMembersInfo } from '@/api/group/types/Group';
+import { useSendComplimentStore } from '@/store/useSendComplimentStore';
 
 interface HoneyGroupProps {
   group: GroupWithMembersInfo[];
@@ -16,6 +17,8 @@ const HoneyGroup = ({ group }: HoneyGroupProps) => {
   const [currentPage, setCurrentPage] = useState(1);
   const totalGroups = group.length || 0;
   const currentGroup = group[currentPage - 1];
+
+  const { setGroupName, setGroupId } = useSendComplimentStore();
 
   const displayedMembers =
     currentGroup.groupMembers.length > 2
@@ -31,6 +34,12 @@ const HoneyGroup = ({ group }: HoneyGroupProps) => {
 
   const handleMoveGroupPage = (link: string) => {
     navigate(link);
+  };
+
+  const handleSendHoney = () => {
+    navigate(`/compliment/send/target`);
+    setGroupName(currentGroup.groupName);
+    setGroupId(currentGroup.groupId);
   };
 
   return (
@@ -65,12 +74,7 @@ const HoneyGroup = ({ group }: HoneyGroupProps) => {
             }
           />
         </CardBox>
-        <Button
-          text="이 그룹에 꿀 보내기"
-          onClick={() => {
-            navigate(`/compliment/send/target`);
-          }}
-        />
+        <Button text="이 그룹에 꿀 보내기" onClick={handleSendHoney} />
       </Container>
       <GroupPagination
         currentPage={currentPage}

--- a/src/features/Profile/components/Profile.tsx
+++ b/src/features/Profile/components/Profile.tsx
@@ -19,7 +19,7 @@ const Profile = () => {
             src="/assets/icons/profile-edit.svg"
             alt="profile_edit"
             onClick={() => {
-              navigate('update');
+              navigate('/profile/update');
             }}
           />
         </ProfileBox>

--- a/src/features/Stamp/components/Stamp/StampCard.tsx
+++ b/src/features/Stamp/components/Stamp/StampCard.tsx
@@ -38,6 +38,7 @@ const StampCardBox = styled.div<{ $isVisible: boolean }>`
   border: 1px solid ${theme.colors.gray10};
   background: ${theme.colors.gray00};
   opacity: ${({ $isVisible }) => ($isVisible ? 1 : 0.4)};
+  margin-bottom: 5px;
 `;
 
 const StampImage = styled.img``;

--- a/src/layouts/SubLayout.tsx
+++ b/src/layouts/SubLayout.tsx
@@ -6,11 +6,16 @@ import BackHeader from '@/components/Header/BackHeader';
 interface SubLayoutProps {
   title: string;
   padding?: string;
+  to?: string;
 }
-const SubLayout: React.FC<SubLayoutProps> = ({ title, padding = '26px' }) => {
+const SubLayout: React.FC<SubLayoutProps> = ({
+  title,
+  padding = '26px',
+  to,
+}) => {
   return (
     <Container $padding={padding}>
-      <BackHeader title={title} />
+      <BackHeader title={title} to={to} />
       <Content>
         <Outlet />
       </Content>

--- a/src/pages/compliment/ComplimentDetailPage.tsx
+++ b/src/pages/compliment/ComplimentDetailPage.tsx
@@ -19,7 +19,6 @@ const ComplimentDetailPage = () => {
   const name = urlParams.get('name');
   const [groupId, setGroupId] = useState<number | null>(null);
   const [sendStatus, setSendStatus] = useState<sendStatusType | null>(null);
-  const accessToken = getAccessToken();
 
   const [showGroupModal, setShowGroupModal] = useState<boolean>(false);
   const [selectedGroup, setSelectedGroup] = useState<number | null>(null);
@@ -110,7 +109,7 @@ const ComplimentDetailPage = () => {
               groupId !== null &&
               groupId !== -1 && <Message>이미 저장된 꿀이에요</Message>
             )}
-            {!accessToken && sendStatus === null && groupId === -1 ? (
+            {!getAccessToken() && sendStatus === null && groupId === -1 ? (
               <KakaoButton
                 text="카카오 로그인하고 꿀 저장하기"
                 onClick={handleLogin}

--- a/src/pages/compliment/send/ComplimentSendTargetPage.tsx
+++ b/src/pages/compliment/send/ComplimentSendTargetPage.tsx
@@ -25,6 +25,7 @@ const ComplimentSendTargetPage = () => {
     receiverName,
     setReceiverName,
     groupName,
+    groupId,
     setGroupName,
     setGroupId,
     ongoing,
@@ -33,7 +34,7 @@ const ComplimentSendTargetPage = () => {
   } = useSendComplimentStore();
   const [errorMsg, setErrorMsg] = useState<string>('');
   const [showGroupModal, setShowGroupModal] = useState<boolean>(false);
-  const [selectedGroup, setSelectedGroup] = useState<number | null>(null);
+  const [selectedGroup, setSelectedGroup] = useState<number | null>(groupId);
 
   const [showModal, setShowModal] = useState<boolean>(false);
 

--- a/src/pages/group/GroupDetailPage.tsx
+++ b/src/pages/group/GroupDetailPage.tsx
@@ -30,13 +30,16 @@ import { useDetailHoneyModalStore } from '@/store/useDetailHoneyModalStore';
 import { useSendComplimentStore } from '@/store/useSendComplimentStore';
 import { useToast } from '@/store/useToast';
 import { theme } from '@/styles/theme';
+import { history } from '@/utils/history';
 import styled from '@emotion/styled';
+import { Action } from 'history';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 const GroupDetailPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
+  const { pathname } = useLocation();
   const { showMoveToast } = useToast();
   /* 그룹 ID, 페이지 크기 */
   const { id } = useParams();
@@ -94,6 +97,7 @@ const GroupDetailPage = () => {
   useEffect(() => {
     setIsSelectMode(false);
   }, [tabValue]);
+
   /* 선택 모드 및 선택한 id 배열 */
   const [isSelectMode, setIsSelectMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
@@ -144,6 +148,21 @@ const GroupDetailPage = () => {
       fetchNextPage?.();
     }
   }, [hasNextPage, isFetching]);
+
+  /* 선택 중 뒤로가기 시 경고 모달 */
+  useEffect(() => {
+    const unlistenHistoryEvent = history.listen(({ action, location }) => {
+      if (
+        (action === Action.Pop || action === Action.Push) &&
+        !location.pathname.startsWith(`/group/${id}`) &&
+        selectedIds.length > 0
+      ) {
+        setShowCancelModal(true);
+        history.push(pathname);
+      }
+    });
+    return unlistenHistoryEvent;
+  }, [selectedIds]);
 
   useEffect(() => {
     if (tabValue === 'send') {

--- a/src/pages/group/GroupDetailPage.tsx
+++ b/src/pages/group/GroupDetailPage.tsx
@@ -27,6 +27,7 @@ import { useGroupReceivedPraise } from '@/hooks/receivedPraise/useGroupReceivedP
 import { useGroupSendPraise } from '@/hooks/sendPraise/useGroupSendPraise';
 import { useReceiveStamp } from '@/hooks/stamp/useReceiveStamp';
 import { useDetailHoneyModalStore } from '@/store/useDetailHoneyModalStore';
+import { useSendComplimentStore } from '@/store/useSendComplimentStore';
 import { useToast } from '@/store/useToast';
 import { theme } from '@/styles/theme';
 import styled from '@emotion/styled';
@@ -43,6 +44,8 @@ const GroupDetailPage = () => {
   const pageSize = 10;
   const { isDetailModalOpen, modalContent, openDetailModal, closeDetailModal } =
     useDetailHoneyModalStore();
+  const { setGroupName: setTargetGroupName, setGroupId } =
+    useSendComplimentStore();
 
   const { data: groupInfo } = useGroupDetail(parseInt(id || '0'));
   const { data: totalStamp } = useReceiveStamp(parseInt(id || '0'));
@@ -241,8 +244,10 @@ const GroupDetailPage = () => {
     );
   };
 
-  const handleWriteCompliment = () => {
+  const handleSendHoney = () => {
     navigate('/compliment/send/target');
+    setTargetGroupName(groupName);
+    setGroupId(groupId);
   };
 
   /* 꿀 옮기기 프로세스 관련 함수 */
@@ -417,7 +422,7 @@ const GroupDetailPage = () => {
         <Button
           variant="normal"
           text="해당 그룹에게 꿀 보내기"
-          onClick={handleWriteCompliment}
+          onClick={handleSendHoney}
         />
       </ButtonWrapper>
       {/* 그룹명 수정 및 삭제 */}
@@ -529,8 +534,8 @@ const GroupDetailPage = () => {
         />
         {showCancelModal && (
           <WarningModal
-            title="꿀 옮기기를 취소하시겠어요?"
-            description="지금 나가면 변경된 내용은 저장되지 않습니다."
+            title="꿀 선택을 취소하시겠어요?"
+            description="지금 나가면 선택한 데이터가 저장되지 않아요."
             cancelText="이전"
             confirmText="나가기"
             onCancel={() => setShowCancelModal(false)}
@@ -604,7 +609,6 @@ const EditButton = styled.button``;
 
 const TotalHoneyContainer = styled.div`
   width: 100%;
-  height: 240px;
   padding: 13px 16px;
   display: flex;
   flex-direction: column;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -62,7 +62,7 @@ const router = createBrowserRouter([
           },
           {
             path: 'profile',
-            element: <SubLayout title="마이페이지" padding="0px" />,
+            element: <SubLayout title="마이페이지" padding="0px" to="/" />,
             children: [{ path: '', element: <ProfilePage /> }],
           },
           {


### PR DESCRIPTION
## 연관 이슈

DD-161

<br/>

## 개요

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요. -->
2차 QA
<br/>

## ✅ 작업 내용

- [x] 해당 그룹에게 꿀 보내기 그룹명 기본 설정 추가
- [x] 그룹 페이지에서 뒤로가기 시 경고 모달 적용
- [x] 뒤로가기 시 무한 경로 오류 수정
- [x] 그룹명 초기값 설정
- [x] 서비스 이용약관 하위 탭 삭제
- [x] accessToken 관련 코드 수정
<br/>

## 🖥 구현 결과

<!--  구현한 기능이 보이는 스크린샷을 업로드해주세요. -->

https://github.com/user-attachments/assets/77407375-5538-4fc1-87ec-cc4bcd935fd2


<br/>


### 📝 기타 사항

<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업 등을 적어주세요. -->
@uiop5809 
- 전에 얘기해준 라우터 무한 반복되는 이슈 사항 수정했습니다!
1. replace=true로 넘긴다.
→ 이렇게 하면 현재 페이지가 대체되어 뒤로가기 할 때 두 번을 클릭해야 했어요.
2. replace=true와 함께 state 값으로 double=true를 넘긴다. BackButton에서 이 값을 가져와 true이면 navigate(-2)를 하고, false이면 원래대로 navigate(-1)를 한다.

- 이렇게 정리했습니다! 그룹 관리>그룹 상세>삭제 후 그룹 관리에서 겪는 경로 무한반복 오류는 위에처럼 해결하였구요!

- 마이페이지의 경우, 헤더에 있기 때문에 사이드바에서 프로필 수정 들어간 후 헤더에 있는 마이페이지를 들어갈 수도 있다는 문제가 있었어요. 또한, 마이페이지에서 프로필 수정으로 이동했다가 뒤로가기를 했을 때 무한반복 된다는 오류의 경우 해결을 위해서는 프로필 수정 페이지에서 `BackButton`을 클릭할 때 `'/profile'`로 경로를 지정해야 하는데, 그렇게 되면 뒤로가기 버튼을 클릭할 때 경고 모달을 표시할 수 있게 하는 history를 인식하지 못하여(뒤로 가기 등은 인식하는데, navigate('경로명')으로 지정될 경우 `useLocation`으로도 인식이 안되더라구요.) 문제가 있었습니다.

- 그래서 이 부분은 기획의 의견을 받아 마이페이지에서 `BackButton` 클릭 시엔 무조건 메인 페이지로 이동하도록 설정하였습니다! 

<br/>
